### PR TITLE
Install vim for editing rails5.2 credential

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
+    vim \
     build-essential \
     nodejs \
     yarn \


### PR DESCRIPTION
構築したDocker環境にvimが入ってなかったので追加してみました。
vimがないと以下が実行できませんでした。

```
docker-compose run --rm rails bin/rails credentials:edit
```